### PR TITLE
Default to the IPv4 loopback address for remote connection listening scripts.

### DIFF
--- a/.github/workflows/wait-for-connection-test.yaml
+++ b/.github/workflows/wait-for-connection-test.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     container:
-      image: us-central1-docker.pkg.dev/tensorflow-sigs/tensorflow/ml-build@sha256:cec01011e627c0fd101c521a8af7c09ce4557ab6dcc9f8678aeb67a3182ed821 # ratchet:tensorflow/ml-build:latest
+      image: "gcr.io/tensorflow-testing/nosla-cuda12.3-cudnn9.1-ubuntu20.04-manylinux2014-multipython:latest"
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # ratchet:actions/checkout@v4
       - name: Echo

--- a/.github/workflows/wait-for-connection-test.yaml
+++ b/.github/workflows/wait-for-connection-test.yaml
@@ -30,20 +30,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ["linux-x86-g2-48-l4-4gpu"]
+        runner: ["linux-x86-n2-16"]
         instances: ["1"]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     container:
-      image: "gcr.io/tensorflow-testing/nosla-cuda12.3-cudnn9.1-ubuntu20.04-manylinux2014-multipython:latest"
+      image: us-central1-docker.pkg.dev/tensorflow-sigs/tensorflow/ml-build@sha256:cec01011e627c0fd101c521a8af7c09ce4557ab6dcc9f8678aeb67a3182ed821 # ratchet:tensorflow/ml-build:latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # ratchet:actions/checkout@v4
       - name: Echo
         run: |
           set -x
-          echo "ipv6 enabled"
-          cat /proc/sys/net/ipv6/conf/all/disable_ipv6
-          echo "------------------------------- DONE -------------------------------"
+          echo "Real job here..."
       # Halt for connection if workflow dispatch is told to or if it is a retry with the label halt_on_retry
       - name: Wait For Connection
         uses: ./ci_connection/

--- a/.github/workflows/wait-for-connection-test.yaml
+++ b/.github/workflows/wait-for-connection-test.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ["linux-x86-n2-16"]
+        runner: ["linux-x86-g2-48-l4-4gpu"]
         instances: ["1"]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
@@ -41,7 +41,9 @@ jobs:
       - name: Echo
         run: |
           set -x
-          echo "Real job here..."
+          echo "ipv6 enabled"
+          cat /proc/sys/net/ipv6/conf/all/disable_ipv6
+          echo "------------------------------- DONE -------------------------------"
       # Halt for connection if workflow dispatch is told to or if it is a retry with the label halt_on_retry
       - name: Wait For Connection
         uses: ./ci_connection/

--- a/ci_connection/notify_connection.py
+++ b/ci_connection/notify_connection.py
@@ -37,7 +37,7 @@ utils.setup_logging()
 _LOCK = threading.Lock()
 
 # Configuration (same as wait_for_connection.py)
-HOST, PORT = "localhost", 12455
+HOST, PORT = "127.0.0.1", 12455
 KEEP_ALIVE_INTERVAL = 30
 
 

--- a/ci_connection/wait_for_connection.py
+++ b/ci_connection/wait_for_connection.py
@@ -146,7 +146,7 @@ async def process_messages(reader, writer):
   writer.close()
 
 
-async def wait_for_connection(host: str = "localhost", port: int = 12455):
+async def wait_for_connection(host: str = "127.0.0.1", port: int = 12455):
   # Print out the data required to connect to this VM
   runner_name = os.getenv("HOSTNAME")
   cluster = os.getenv("CONNECTION_CLUSTER")


### PR DESCRIPTION
IPv4 is a safer bet across all images than IPv6, which may not be enabled/set up correctly in some cases at the moment.