### PR TITLE
Allow waiting in nightlies/continuous re-runs; make waiting more robust.

### DIFF
--- a/.github/workflows/wait-for-connection-test.yaml
+++ b/.github/workflows/wait-for-connection-test.yaml
@@ -44,6 +44,8 @@ jobs:
           echo "Real job here..."
       # Halt for connection if workflow dispatch is told to or if it is a retry with the label halt_on_retry
       - name: Wait For Connection
+        env:
+          MLCI_WAIT_AFTER_HALT_CHECK: 1
         uses: ./ci_connection/
         with:
           halt-dispatch-input: ${{ inputs.halt-for-connection }}

--- a/.github/workflows/wait-for-connection-test.yaml
+++ b/.github/workflows/wait-for-connection-test.yaml
@@ -44,8 +44,6 @@ jobs:
           echo "Real job here..."
       # Halt for connection if workflow dispatch is told to or if it is a retry with the label halt_on_retry
       - name: Wait For Connection
-        env:
-          MLCI_WAIT_AFTER_HALT_CHECK: 1
         uses: ./ci_connection/
         with:
           halt-dispatch-input: ${{ inputs.halt-for-connection }}

--- a/ci_connection/utils.py
+++ b/ci_connection/utils.py
@@ -39,19 +39,8 @@ STATE_ENV_FILENAME = "env.txt"
 STATE_ENV_OUT_PATH = os.path.join(STATE_OUT_DIR, STATE_ENV_FILENAME)
 
 
-# Check if debug logging should be enabled for the scripts:
-# WAIT_FOR_CONNECTION_DEBUG is a custom variable.
-# RUNNER_DEBUG and ACTIONS_RUNNER_DEBUG are GH env vars, which can be set
-# in various ways, one of them - enabling debug logging from the UI, when
-# triggering a run:
-# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging#enabling-runner-diagnostic-logging
-_SHOW_DEBUG = bool(
-  os.getenv(
-    "WAIT_FOR_CONNECTION_DEBUG",
-    os.getenv("RUNNER_DEBUG", os.getenv("ACTIONS_RUNNER_DEBUG")),
-  )
-)
+# Check if debug logging should be enabled for the scripts.
+_SHOW_DEBUG = bool(os.getenv("MLCI_CONNECTION_DEBUG_LOGGING"))
 
 
 _ANSI = {

--- a/ci_connection/utils.py
+++ b/ci_connection/utils.py
@@ -49,8 +49,7 @@ STATE_ENV_OUT_PATH = os.path.join(STATE_OUT_DIR, STATE_ENV_FILENAME)
 _SHOW_DEBUG = bool(
   os.getenv(
     "WAIT_FOR_CONNECTION_DEBUG",
-    os.getenv("ACTIONS_RUNNER_DEBUG",
-              os.getenv("ACTIONS_STEP_DEBUG"))
+    os.getenv("RUNNER_DEBUG"),
   )
 )
 

--- a/ci_connection/utils.py
+++ b/ci_connection/utils.py
@@ -39,8 +39,20 @@ STATE_ENV_FILENAME = "env.txt"
 STATE_ENV_OUT_PATH = os.path.join(STATE_OUT_DIR, STATE_ENV_FILENAME)
 
 
-# Check if debug logging should be enabled for the scripts.
-_SHOW_DEBUG = bool(os.getenv("MLCI_CONNECTION_DEBUG_LOGGING"))
+# Check if debug logging should be enabled for the scripts:
+# WAIT_FOR_CONNECTION_DEBUG is a custom variable.
+# ACTIONS_RUNNER_DEBUG is a GH env vars, which can be set
+# in various ways, one of them - enabling debug logging from the UI, when
+# triggering a run:
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging#enabling-runner-diagnostic-logging
+_SHOW_DEBUG = bool(
+  os.getenv(
+    "WAIT_FOR_CONNECTION_DEBUG",
+    os.getenv("ACTIONS_RUNNER_DEBUG",
+              os.getenv("ACTIONS_STEP_DEBUG"))
+  )
+)
 
 
 _ANSI = {

--- a/ci_connection/utils.py
+++ b/ci_connection/utils.py
@@ -41,11 +41,12 @@ STATE_ENV_OUT_PATH = os.path.join(STATE_OUT_DIR, STATE_ENV_FILENAME)
 
 # Check if debug logging should be enabled for the scripts:
 # WAIT_FOR_CONNECTION_DEBUG is a custom variable.
-# ACTIONS_RUNNER_DEBUG is a GH env vars, which can be set
+# RUNNER_DEBUG is a GH env var, which can be set
 # in various ways, one of them - enabling debug logging from the UI, when
 # triggering a run:
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
 # https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging#enabling-runner-diagnostic-logging
+# Note that the above mentions ACTIONS_RUNNER_DEBUG, but it doesn't appear to get set - perhaps it is set via secrets
 _SHOW_DEBUG = bool(
   os.getenv(
     "WAIT_FOR_CONNECTION_DEBUG",

--- a/ci_connection/wait_for_connection.py
+++ b/ci_connection/wait_for_connection.py
@@ -68,10 +68,7 @@ def is_debug_logging_enabled_and_job_type_is_schedule_or_workflow_dispatch() -> 
   This is useful, or even necessary, as it currently appears to be the sole way
   of marking a continuous job, or a re-run of a nightly job to wait for connection.
   """
-  _actions_runner_debug_enabled = _is_true_like_env_var("ACTIONS_RUNNER_DEBUG")
-  _actions_step_debug_enabled = _is_true_like_env_var("ACTIONS_STEP_DEBUG")
-
-  actions_debug_enabled = _actions_runner_debug_enabled or _actions_step_debug_enabled
+  actions_debug_enabled = _is_true_like_env_var("RUNNER_DEBUG")
 
   event_name = os.getenv("GITHUB_EVENT_NAME")
   is_schedule_or_workflow_dispatch = event_name in {"schedule", "workflow_dispatch"}
@@ -149,9 +146,10 @@ def should_halt_for_connection(
 
   logging.info("Checking if the workflow should be halted for a connection...")
 
+  _wait_after_halt_check_var_name = "MLCI_WAIT_AFTER_HALT_CHECK"
   if not wait_after_conditions_check:
     # Useful for debugging why halting conditions were/were not triggered
-    wait_after_conditions_check = _is_true_like_env_var("MLCI_WAIT_AFTER_HALT_CHECK")
+    wait_after_conditions_check = _is_true_like_env_var(_wait_after_halt_check_var_name)
 
   if not wait_after_conditions_check and wait_regardless:
     logging.info("Wait for connection requested explicitly via code")
@@ -184,7 +182,10 @@ def should_halt_for_connection(
       sys.exit(1)
 
   if wait_after_conditions_check:
-    logging.info("Wait for connection requested explicitly via code, or ")
+    logging.info(
+      "Wait for connection requested explicitly via code, "
+      f"or {_wait_after_halt_check_var_name}"
+    )
     return True
 
   return False

--- a/ci_connection/wait_for_connection.py
+++ b/ci_connection/wait_for_connection.py
@@ -68,24 +68,26 @@ def is_debug_logging_enabled_and_job_type_is_schedule_or_workflow_dispatch() -> 
   This is useful, or even necessary, as it currently appears to be the sole way
   of marking a continuous job, or a re-run of a nightly job to wait for connection.
   """
-  actions_runner_debug_enabled = _is_true_like_env_var("ACTIONS_RUNNER_DEBUG")
+  _actions_runner_debug_enabled = _is_true_like_env_var("ACTIONS_RUNNER_DEBUG")
+  _actions_step_debug_enabled = _is_true_like_env_var("ACTIONS_STEP_DEBUG")
+
+  actions_debug_enabled = _actions_runner_debug_enabled or _actions_step_debug_enabled
 
   event_name = os.getenv("GITHUB_EVENT_NAME")
   is_schedule_or_workflow_dispatch = event_name in {"schedule", "workflow_dispatch"}
 
-  result = actions_runner_debug_enabled and is_schedule_or_workflow_dispatch
+  result = actions_debug_enabled and is_schedule_or_workflow_dispatch
   if result:
     logging.info(
-      "Job is of the 'schedule/workflow_dispatch' type, and runner "
-      "debugging is enabled"
+      "Job is of the 'schedule/workflow_dispatch' type, and runner debugging is enabled"
     )
   else:
     if not is_schedule_or_workflow_dispatch:
       logging.debug(f"Job type is {event_name}, not 'schedule' or 'workflow_dispatch'")
-    if not actions_runner_debug_enabled:
+    if not actions_debug_enabled:
       logging.debug(
         f"Job does not have logging enabled: "
-        f"ACTIONS_RUNNER_DEBUG={actions_runner_debug_enabled}"
+        f"ACTIONS_RUNNER_DEBUG={actions_debug_enabled}"
       )
   return result
 
@@ -140,12 +142,18 @@ def check_if_labels_require_connection_halting() -> Optional[bool]:
   return False
 
 
-def should_halt_for_connection(wait_regardless: bool = False) -> bool:
+def should_halt_for_connection(
+  wait_regardless: bool = False, wait_after_conditions_check: bool = False
+) -> bool:
   """Check if the workflow should wait, due to inputs, vars, and labels."""
 
   logging.info("Checking if the workflow should be halted for a connection...")
 
-  if wait_regardless:
+  if not wait_after_conditions_check:
+    # Useful for debugging why halting conditions were/were not triggered
+    wait_after_conditions_check = _is_true_like_env_var("MLCI_WAIT_AFTER_HALT_CHECK")
+
+  if not wait_after_conditions_check and wait_regardless:
     logging.info("Wait for connection requested explicitly via code")
     return True
 
@@ -168,11 +176,16 @@ def should_halt_for_connection(wait_regardless: bool = False) -> bool:
   if labels_require_halting:
     return True
   if labels_require_halting is None:
-    logging.critical(
-      "Exiting due to inability to retrieve PR labels, and no "
-      "other halting conditions being met"
-    )
-    sys.exit(1)
+    if not wait_after_conditions_check:
+      logging.critical(
+        "Exiting due to inability to retrieve PR labels, and no "
+        "other halting conditions being met"
+      )
+      sys.exit(1)
+
+  if wait_after_conditions_check:
+    logging.info("Wait for connection requested explicitly via code, or ")
+    return True
 
   return False
 
@@ -304,9 +317,12 @@ async def wait_for_connection(host: str = "127.0.0.1", port: int = 12455):
     logging.info("Waiting process terminated.")
 
 
-def main(wait_regardless: bool = False):
+def main(wait_regardless: bool = False, wait_after_conditions_check: bool = False):
   try:
-    if should_halt_for_connection(wait_regardless=wait_regardless):
+    if should_halt_for_connection(
+      wait_regardless=wait_regardless,
+      wait_after_conditions_check=wait_after_conditions_check,
+    ):
       asyncio.run(wait_for_connection())
     else:
       logging.info("No conditions for halting the workflow for connection were met")

--- a/ci_connection/wait_for_connection.py
+++ b/ci_connection/wait_for_connection.py
@@ -83,8 +83,7 @@ def is_debug_logging_enabled_and_job_type_is_schedule_or_workflow_dispatch() -> 
       logging.debug(f"Job type is {event_name}, not 'schedule' or 'workflow_dispatch'")
     if not actions_debug_enabled:
       logging.debug(
-        f"Job does not have logging enabled: "
-        f"ACTIONS_RUNNER_DEBUG={actions_debug_enabled}"
+        f"Job does not have logging enabled: RUNNER_DEBUG={actions_debug_enabled}"
       )
   return result
 


### PR DESCRIPTION
Waits if a job is triggered via workflow_dispatch or is a scheduled job, and debug logging is enabled.

This improves label retrieval - fixes some bugs and better safe-guards requests.

Adds a simple Bash-based fallback command in case the user is having issues connecting via the Python-based entrypoint.