### PR TITLE
Add Clang-format checker GitHub Action

### DIFF
--- a/ci_clangformat/.clang-format.default
+++ b/ci_clangformat/.clang-format.default
@@ -1,0 +1,6 @@
+BasedOnStyle: Google
+Language: Cpp
+PointerBindsToType: true
+SortIncludes: Never
+AlignTrailingComments:
+  Kind: Always

--- a/ci_clangformat/README.md
+++ b/ci_clangformat/README.md
@@ -1,0 +1,1 @@
+# CI Clang-format

--- a/ci_clangformat/README.md
+++ b/ci_clangformat/README.md
@@ -1,1 +1,30 @@
 # CI Clang-format
+
+This composite action helps maintain consistent C/C++ code style by running
+`clang-format` on modified files in your pull requests. It checks for
+formatting violations and will cause the workflow to fail if any issues are
+found, ensuring code quality before merging.
+
+The action uses your .clang-format style file if present in the repository
+root; otherwise, it will use the .clang-format.default under this folder.
+
+This action offers the following configuration through its inputs:
+* `clang_format_version`: Choose the exact clang-format version to use,
+ with `20.1.5` as the default to align with recent stable releases.
+* `branch_name`: Specify the name of your repository branch (`main` by
+ default) for comparing changes within the pull requests.
+
+## Resolving Formatting Failures
+If a workflow run fails due to formatting violations, you're expected to
+fix the issues locally. Simply run `clang-format` on the problematic
+files, e.g., using
+`pipx run clang-format==20.1.5 --style=file --Werror -i <files>`,
+and then commit the formatted code to your pull request.
+
+## Pipx Requirement
+This action leverages `pipx` to reliably install and run specific
+`clang-format` versions, ensuring consistent behavior across different
+environments. `pipx` is generally pre-installed on GitHub Actions hosted
+runners (you can verify available tools on the runner images [doc](https://github.com/actions/runner-images?tab=readme-ov-file#available-images)).
+If `pipx` does not exist, you'll need to include a step to install it
+in your workflow's running environment.

--- a/ci_clangformat/action.yaml
+++ b/ci_clangformat/action.yaml
@@ -15,18 +15,13 @@ name: "Check clang-format"
 description: 'Action to run clang-format on changed files'
 inputs:
   clang_format_version:
-    description: 'The clang-format version to use (e.g., "17", "18").'
+    description: 'The clang-format version to use.'
     required: true
-    default: "17.0.6"
+    default: "20.1.5"
   branch_name:
-    description: 'The name of the branch (e.g., "main") used for fetching comparisons.'
+    description: 'The repository branch used for fetching comparisons.'
     required: true
     default: 'main'
-
-# outputs:
-#   changes_detected:
-#     description: 'True if clang-format detected formatting changes.'
-#     value: ${{ steps.check-format.outputs.changes_detected }}
 
 runs:
   using: "composite"
@@ -36,44 +31,6 @@ runs:
   - name: "Fetch HEAD of ${{ inputs.branch_name }} branch"
     shell: bash
     run: git fetch origin ${{ inputs.branch_name }} --depth=1
-  # - name: "Determine and install clang-format"
-  #   shell: bash
-  #   id: install-clang-format
-  #   run: |
-  #     CLANG_VERSION="${{ inputs.clang_format_version }}"
-  #     CLANG_FORMAT_NAME=""
-
-  #     if [ "$CLANG_VERSION" == "latest" ]; then
-  #       CLANG_FORMAT_NAME="clang-format"
-  #     else
-  #       CLANG_FORMAT_NAME="clang-format-${CLANG_VERSION}"
-  #     fi
-      
-  #     if command -v "$CLANG_FORMAT_NAME" &> /dev/null; then
-  #       echo "::notice::'$CLANG_FORMAT_NAME' is already installed."
-  #     else
-  #       echo "::warning::'$CLANG_FORMAT_NAME' not found. Installing..."
-  #       sudo apt-get update
-  #       if ! sudo apt-get install -y "$CLANG_FORMAT_NAME"; then
-  #         echo "::error::Failed to install '$CLANG_FORMAT_NAME'. Please check the version or try 'latest'."
-  #         exit 1
-  #       fi
-  #     fi
-  #     echo "clang_format_exe=$CLANG_FORMAT_NAME" >> "$GITHUB_OUTPUT"
-  # - name: "Prepare .clang-format file"
-  #   shell: bash
-  #   id: prepare-config
-  #   run: |
-  #     REPO_CLANG_FORMAT=".clang-format"
-  #     ACTION_DEFAULT_CLANG_FORMAT="${{ github.action_path }}/.clang-format.default"
-
-  #     if [ -f "$REPO_CLANG_FORMAT" ]; then
-  #       echo "::notice::Using repository's .clang-format file."
-  #       # cat "$REPO_CLANG_FORMAT"
-  #     else [ -f "$ACTION_DEFAULT_CLANG_FORMAT" ]; then
-  #       echo "::notice::Repository does not have a .clang-format file. Using the action's default."
-  #       cp "$ACTION_DEFAULT_CLANG_FORMAT" "$REPO_CLANG_FORMAT"
-  #     fi
   - name: Run clang-format check
     id: check-format
     shell: bash

--- a/ci_clangformat/action.yaml
+++ b/ci_clangformat/action.yaml
@@ -15,7 +15,7 @@ name: "Check clang-format"
 description: 'Action to run clang-format on changed files'
 inputs:
   clang_format_version:
-    description: 'The clang-format version to use (e.g., "17", "18", "latest").'
+    description: 'The clang-format version to use (e.g., "17", "18").'
     required: true
     default: "17.0.6"
   branch_name:
@@ -23,10 +23,10 @@ inputs:
     required: true
     default: 'main'
 
-outputs:
-  changes_detected:
-    description: 'True if clang-format detected formatting changes.'
-    value: ${{ steps.check-format.outputs.changes_detected }}
+# outputs:
+#   changes_detected:
+#     description: 'True if clang-format detected formatting changes.'
+#     value: ${{ steps.check-format.outputs.changes_detected }}
 
 runs:
   using: "composite"

--- a/ci_clangformat/action.yaml
+++ b/ci_clangformat/action.yaml
@@ -86,13 +86,6 @@ runs:
         # pipx installs and runs clang-format with a specific version.
         pipx run clang-format==${{ inputs.clang_format_version }} --dry-run --Werror --verbose $(git diff --name-only origin/main HEAD -- '*.cc' '*.h')
       else
+        echo "::notice::Repository does not have a .clang-format file. Using the action's default."
         pipx run clang-format==${{ inputs.clang_format_version }} -style=file:$ACTION_DEFAULT_CLANG_FORMAT --dry-run --Werror --verbose $(git diff --name-only origin/main HEAD -- '*.cc' '*.h')
       fi
-
-      # CLANG_FORMAT_EXE="${{ steps.install-clang-format.outputs.clang_format_exe }}"
-      # PATHS_TO_CHECK="${{ inputs.paths_to_check }}"
-      # EXCLUDE_REGEX="${{ inputs.exclude_regex }}"
-      # echo "Running $CLANG_FORMAT_EXE check on paths: $PATHS_TO_CHECK"
-      # if [ -n "$EXCLUDE_REGEX" ]; then
-      #   echo "Excluding regex: $EXCLUDE_REGEX"
-      # fi

--- a/ci_clangformat/action.yaml
+++ b/ci_clangformat/action.yaml
@@ -1,0 +1,98 @@
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: "Check clang-format"
+description: 'Action to run clang-format on changed files'
+inputs:
+  clang_format_version:
+    description: 'The clang-format version to use (e.g., "17", "18", "latest").'
+    required: true
+    default: "17.0.6"
+  branch_name:
+    description: 'The name of the branch (e.g., "main") used for fetching comparisons.'
+    required: true
+    default: 'main'
+
+outputs:
+  changes_detected:
+    description: 'True if clang-format detected formatting changes.'
+    value: ${{ steps.check-format.outputs.changes_detected }}
+
+runs:
+  using: "composite"
+  steps:
+  - name: "Checking out repository"
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  - name: "Fetch HEAD of ${{ inputs.branch_name }} branch"
+    shell: bash
+    run: git fetch origin ${{ inputs.branch_name }} --depth=1
+  # - name: "Determine and install clang-format"
+  #   shell: bash
+  #   id: install-clang-format
+  #   run: |
+  #     CLANG_VERSION="${{ inputs.clang_format_version }}"
+  #     CLANG_FORMAT_NAME=""
+
+  #     if [ "$CLANG_VERSION" == "latest" ]; then
+  #       CLANG_FORMAT_NAME="clang-format"
+  #     else
+  #       CLANG_FORMAT_NAME="clang-format-${CLANG_VERSION}"
+  #     fi
+      
+  #     if command -v "$CLANG_FORMAT_NAME" &> /dev/null; then
+  #       echo "::notice::'$CLANG_FORMAT_NAME' is already installed."
+  #     else
+  #       echo "::warning::'$CLANG_FORMAT_NAME' not found. Installing..."
+  #       sudo apt-get update
+  #       if ! sudo apt-get install -y "$CLANG_FORMAT_NAME"; then
+  #         echo "::error::Failed to install '$CLANG_FORMAT_NAME'. Please check the version or try 'latest'."
+  #         exit 1
+  #       fi
+  #     fi
+  #     echo "clang_format_exe=$CLANG_FORMAT_NAME" >> "$GITHUB_OUTPUT"
+  # - name: "Prepare .clang-format file"
+  #   shell: bash
+  #   id: prepare-config
+  #   run: |
+  #     REPO_CLANG_FORMAT=".clang-format"
+  #     ACTION_DEFAULT_CLANG_FORMAT="${{ github.action_path }}/.clang-format.default"
+
+  #     if [ -f "$REPO_CLANG_FORMAT" ]; then
+  #       echo "::notice::Using repository's .clang-format file."
+  #       # cat "$REPO_CLANG_FORMAT"
+  #     else [ -f "$ACTION_DEFAULT_CLANG_FORMAT" ]; then
+  #       echo "::notice::Repository does not have a .clang-format file. Using the action's default."
+  #       cp "$ACTION_DEFAULT_CLANG_FORMAT" "$REPO_CLANG_FORMAT"
+  #     fi
+  - name: Run clang-format check
+    id: check-format
+    shell: bash
+    run: |
+      REPO_CLANG_FORMAT=".clang-format"
+      ACTION_DEFAULT_CLANG_FORMAT="${{ github.action_path }}/.clang-format.default"
+
+      if [ -f "$REPO_CLANG_FORMAT" ]; then
+        echo "::notice::Using repository's .clang-format file."
+        # pipx installs and runs clang-format with a specific version.
+        pipx run clang-format==${{ inputs.clang_format_version }} --dry-run --Werror --verbose $(git diff --name-only origin/main HEAD -- '*.cc' '*.h')
+      else
+        pipx run clang-format==${{ inputs.clang_format_version }} -style=file:$ACTION_DEFAULT_CLANG_FORMAT --dry-run --Werror --verbose $(git diff --name-only origin/main HEAD -- '*.cc' '*.h')
+      fi
+
+      # CLANG_FORMAT_EXE="${{ steps.install-clang-format.outputs.clang_format_exe }}"
+      # PATHS_TO_CHECK="${{ inputs.paths_to_check }}"
+      # EXCLUDE_REGEX="${{ inputs.exclude_regex }}"
+      # echo "Running $CLANG_FORMAT_EXE check on paths: $PATHS_TO_CHECK"
+      # if [ -n "$EXCLUDE_REGEX" ]; then
+      #   echo "Excluding regex: $EXCLUDE_REGEX"
+      # fi


### PR DESCRIPTION
Add a new GitHub Composite Action to automatically enforce C/C++ code formatting using `clang-format` in pull requests.

It provides a reusable and standardized action for CI/CD, eliminating the need for individual teams or users to duplicate clang-format setup in their workflows.