### PR TITLE
Fix detection of missing extra packages

### DIFF
--- a/python_seed_env/src/seed_env/config.py
+++ b/python_seed_env/src/seed_env/config.py
@@ -35,11 +35,13 @@ GPU_SPECIFIC_DEPS = [
   "nvidia-nccl-cu12",
   "nvidia-nvjitlink-cu12",
   "nvidia-nvshmem-cu12",
+  "nvidia-nvshmem-cu13",
   "jax-cuda12-plugin",
+  # "jax-cuda12-plugin[with-cuda]",
   "jax-cuda12-pjrt",
   "transformer-engine",
-  "transformer-engine[jax]",
-  "transformer-engine[pytorch]",
+  # "transformer-engine[jax]",
+  # "transformer-engine[pytorch]",
 ]
 
 TPU_SPECIFIC_DEPS = [

--- a/python_seed_env/src/seed_env/uv_utils.py
+++ b/python_seed_env/src/seed_env/uv_utils.py
@@ -280,6 +280,7 @@ def _get_required_dependencies_from_pyproject_toml(file_path="pyproject.toml"):
           .split("<")[0]
           .split(">")[0]
           .split("!=")[0]
+          .split("[")[0] # Get the package name without extra
           .strip()
         )
         deps.append(package_name)


### PR DESCRIPTION
The _remove_hardware_specific_deps function failed to exclude jax-cuda12-plugin[with-cuda]. This change should fix the error.