### PR TITLE
Add the extra index url for nvidia deps in JAX's lock files

### DIFF
--- a/python_seed_env/src/seed_env/uv_utils.py
+++ b/python_seed_env/src/seed_env/uv_utils.py
@@ -71,6 +71,7 @@ def build_seed_env(
       )
       raise
 
+  # TODO(kanglant): Remove this index url later; modify seed lock file before running uv add command
   command = [
     "uv",
     "add",
@@ -82,6 +83,8 @@ def build_seed_env(
     output_dir,
     "-r",
     seed_lock_file,
+    "--extra-index-url",
+    "https://pypi.nvidia.com",
   ]
   run_command(command)
 


### PR DESCRIPTION
`uv add -r <file.txt>` does not read the url index in the file: https://github.com/jax-ml/jax/blob/main/build/requirements_lock_3_11.txt#L7.

Add it to the seed-env utils function for a temp quick fix. I'll remove it and handle the gpu deps in a better way in a later PR.