### PR TITLE
Allow a custom pyproject.toml template

### DIFF
--- a/python_seed_env/src/seed_env/cli.py
+++ b/python_seed_env/src/seed_env/cli.py
@@ -84,6 +84,12 @@ def main():
 
   # --- Common Arguments ---
   parser.add_argument(
+    "--template-pyproject-toml",
+    type=str,
+    default=None,
+    help="Path to a custom pyproject.toml file to use as a template.",
+  )
+  parser.add_argument(
     "--seed-config",
     type=str,
     default="jax_seed.yaml",
@@ -207,6 +213,7 @@ def main():
       hardware=args.hardware,
       build_pypi_package=args.build_pypi_package,
       output_dir=args.output_dir,
+      template_pyproject_toml=args.template_pyproject_toml,
     )
     # Core function
     host_env_seeder.seed_environment()

--- a/python_seed_env/src/seed_env/config.py
+++ b/python_seed_env/src/seed_env/config.py
@@ -52,12 +52,9 @@ GPU_SPECIFIC_DEPS = [
   "nvidia-nvvm",
   "jax-cuda12-plugin",
   "jax-cuda13-plugin",
-  # "jax-cuda12-plugin[with-cuda]",
   "jax-cuda12-pjrt",
   "jax-cuda13-pjrt",
   "transformer-engine",
-  # "transformer-engine[jax]",
-  # "transformer-engine[pytorch]",
 ]
 
 TPU_SPECIFIC_DEPS = [

--- a/python_seed_env/src/seed_env/utils.py
+++ b/python_seed_env/src/seed_env/utils.py
@@ -98,21 +98,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "{project_name}"
-description = "{project_name} is a simple, performant and scalable Jax LLM!"
 version = "0.0.1"
-readme = "README.md"
 license = "Apache-2.0"
-license-files = ["LICENSE"]
-keywords = ["llm", "jax", "llama", "mistral", "mixtral", "gemma", "deepseek"]
 requires-python = "=={python_version}.*"
 dependencies = [
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
     "Programming Language :: Python",
 ]
 
-# TODO(kanglant): Remove this once maxtext src-layout restructure done.
 [tool.hatch.build.targets.wheel]
 packages = ["{project_name}"]
 

--- a/python_seed_env/tests/test_core.py
+++ b/python_seed_env/tests/test_core.py
@@ -57,10 +57,8 @@ def test_environment_seeder_init_invalid_seed():
 def test_seed_environment_remote(mocker, tmp_path):
   # Mock all external dependencies
   mock_download = mocker.patch(
-    "seed_env.core.download_remote_git_file", return_value=str(tmp_path / "host.txt")
-  )
-  mock_generate_pyproject = mocker.patch(
-    "seed_env.core.generate_minimal_pyproject_toml"
+      "seed_env.core.download_remote_git_file",
+      return_value=str(tmp_path / "host.txt"),
   )
   mock_merge_project_toml_files = mocker.patch("seed_env.core.merge_project_toml_files")
   mock_build_env = mocker.patch("seed_env.core.build_seed_env")
@@ -74,6 +72,11 @@ def test_seed_environment_remote(mocker, tmp_path):
   )
   mocker.patch("seed_env.core.Seeder", return_value=mock_seeder_instance)
 
+  # 4. Instantiate and run the seeder.
+  template_toml_path = tmp_path / "pyproject.toml"
+  template_toml_path.write_text(
+      '[project]\nname = "myproj"\nreadme = "README.md"\n[tool.hatch.build.targets.wheel]\npackages = ["myproj"]'
+  )
   seeder = EnvironmentSeeder(
     host_name="myproj",
     host_source_type="remote",
@@ -86,16 +89,17 @@ def test_seed_environment_remote(mocker, tmp_path):
     hardware="cpu",
     build_pypi_package=True,
     output_dir=str(tmp_path / "output"),
+    template_pyproject_toml=str(template_toml_path),
   )
   seeder.seed_environment()
 
   # Assert all mocks were called
   assert mock_download.called
-  assert mock_generate_pyproject.called
+  # assert mock_generate_pyproject.called
   assert mock_build_env.called
   assert mock_merge_project_toml_files.called
   assert mock_build_pypi.called
-  assert mock_seeder_instance.download_seed_lock_requirement.called
+  mock_seeder_instance.download_seed_lock_requirement.assert_called_with("3.12")
 
 
 def test_seed_environment_local_file_not_found(mocker, tmp_path):

--- a/python_seed_env/tests/test_core.py
+++ b/python_seed_env/tests/test_core.py
@@ -57,8 +57,8 @@ def test_environment_seeder_init_invalid_seed():
 def test_seed_environment_remote(mocker, tmp_path):
   # Mock all external dependencies
   mock_download = mocker.patch(
-      "seed_env.core.download_remote_git_file",
-      return_value=str(tmp_path / "host.txt"),
+    "seed_env.core.download_remote_git_file",
+    return_value=str(tmp_path / "host.txt"),
   )
   mock_merge_project_toml_files = mocker.patch("seed_env.core.merge_project_toml_files")
   mock_build_env = mocker.patch("seed_env.core.build_seed_env")
@@ -75,7 +75,7 @@ def test_seed_environment_remote(mocker, tmp_path):
   # 4. Instantiate and run the seeder.
   template_toml_path = tmp_path / "pyproject.toml"
   template_toml_path.write_text(
-      '[project]\nname = "myproj"\nreadme = "README.md"\n[tool.hatch.build.targets.wheel]\npackages = ["myproj"]'
+    '[project]\nname = "myproj"\nreadme = "README.md"\n[tool.hatch.build.targets.wheel]\npackages = ["myproj"]'
   )
   seeder = EnvironmentSeeder(
     host_name="myproj",

--- a/python_seed_env/tests/test_utils.py
+++ b/python_seed_env/tests/test_utils.py
@@ -159,7 +159,7 @@ version = "0.1.0"
   assert mock_os_remove.called
   assert mock_lock_to_lower_bound_project.called
   # Check for the expected uv remove command
-  assert mock_remove_hardware_specific_deps.call_count == 2
+  assert mock_remove_hardware_specific_deps.call_count == 1
 
   # Collect all commands passed to run_command
   commands = [call.args[0] for call in mock_run_command.call_args_list]


### PR DESCRIPTION
This update enables users to provide a custom pyproject.toml file as a template for the files generated by seed-env.

Here is how the new functionality works:
* The tool can now accept a user-provided pyproject.toml template by using a `--template-pyproject-toml` flag.
* By default, if a pyproject.toml file is present at the directory where the seed-env CLI is called, the tool will assume it is the project root and automatically use this pyproject.toml as the template.
* The custom pyproject.toml template should contain at least a `[project]` table and a `[build-system]` table.
* The template file used for input cannot be the same as the pyproject.toml file generated in the `--output-dir`.
* Disallow a pre-existing pyproject.toml in the `--output-dir`.

Additionally, remove the `_remove_hardware_specific_deps` call after adding host dependencies. The host should use separate requirements files for different platforms, with each file containing all the direct dependencies needed for its specific platform.