### PR TITLE
Add initial tests for CPU runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@ self-hosted-runner:
   labels:
     - "windows-x86-n2-16"
     - "linux-x86-n2-16"
+    - "linux-arm64-c4a-16"

--- a/.github/workflows/actions-cpu-e2e-test.yaml
+++ b/.github/workflows/actions-cpu-e2e-test.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         runner: ["linux-x86-n2-16", "linux-arm64-c4a-16", "windows-x86-n2-16"]
     runs-on: ${{ matrix.runner }}
-    container: ${{ (contains(runner, 'linux-x86') && 'us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest') ||
-                   (contains(runner, 'linux-arm64') && 'us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-arm64:latest') ||
-                   (contains(runner, 'windows-x86') && null) }}
+    container: ${{ (contains(matrix.runner, 'linux-x86') && 'us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest') ||
+                   (contains(matrix.runner, 'linux-arm64') && 'us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-arm64:latest') ||
+                   (contains(matrix.runner, 'windows-x86') && null) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:

--- a/.github/workflows/actions-cpu-e2e-test.yaml
+++ b/.github/workflows/actions-cpu-e2e-test.yaml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '0 9 * * *' # (UTC 9am everyday, and it corresponds to 2 am PDT everyday.)
 
+permissions: {}
+
 jobs:
   test-runner:
     strategy:

--- a/.github/workflows/actions-cpu-e2e-test.yaml
+++ b/.github/workflows/actions-cpu-e2e-test.yaml
@@ -16,8 +16,11 @@ jobs:
   test-runner:
     strategy:
       matrix:
-        runner: ["linux-x86-n2-16", "windows-x86-n2-16"]
+        runner: ["linux-x86-n2-16", "linux-arm64-c4a-16", "windows-x86-n2-16"]
     runs-on: ${{ matrix.runner }}
+    container: ${{ (contains(runner, 'linux-x86') && 'us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest') ||
+                   (contains(runner, 'linux-arm64') && 'us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-arm64:latest') ||
+                   (contains(runner, 'windows-x86') && null) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:

--- a/.github/workflows/actions-cpu-e2e-test.yaml
+++ b/.github/workflows/actions-cpu-e2e-test.yaml
@@ -6,9 +6,6 @@ on:
       triggering_job_id:
         description: 'ID of the Kokoro job that triggered this workflow'
         required: false
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: '0 9 * * *' # (UTC 9am everyday, and it corresponds to 2 am PDT everyday.)
 

--- a/.github/workflows/actions-cpu-e2e-test.yaml
+++ b/.github/workflows/actions-cpu-e2e-test.yaml
@@ -1,0 +1,29 @@
+name: CPU End-to-End Test
+
+on:
+  workflow_dispatch: # Allows manual triggering or via Github API
+    inputs:
+      triggering_job_id:
+        description: 'ID of the Kokoro job that triggered this workflow'
+        required: false
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 9 * * *' # (UTC 9am everyday, and it corresponds to 2 am PDT everyday.)
+
+jobs:
+  test-runner:
+    strategy:
+      matrix:
+        runner: ["linux-x86-n2-16", "windows-x86-n2-16"]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Simulate running a job on ${{ matrix.runner }}
+        run: |
+          echo "Starting a job on runner: ${{ matrix.runner }}..."
+          sleep 30
+          echo "Job finished on runner: ${{ matrix.runner }}."


### PR DESCRIPTION
This will test Linux x86, Linux ARM64 and Windows x86 runners. The test will run at a fixed time everyday.