### PR TITLE
Extract metric parser to shared lib and fix null bug

### DIFF
--- a/benchmarking/static_threshold_analyzer/BUILD.bazel
+++ b/benchmarking/static_threshold_analyzer/BUILD.bazel
@@ -30,6 +30,7 @@ py_binary(
     main = "static_threshold_analyzer.py",
     srcs = ["static_threshold_analyzer.py"],
     deps = [
+        "//benchmarking/utils:metric_parser",
         ":static_threshold_analyzer_lib",
     ],
 )

--- a/benchmarking/static_threshold_analyzer/static_threshold_analyzer.py
+++ b/benchmarking/static_threshold_analyzer/static_threshold_analyzer.py
@@ -19,33 +19,12 @@ Script to perform static threshold analysis on a benchmark result.
 import argparse
 import json
 import sys
-from typing import List
 from google.protobuf import json_format
+from benchmarking.utils import metric_parser
 from benchmarking.proto import benchmark_result_pb2
-from benchmarking.proto.common import metric_pb2
 from benchmarking.static_threshold_analyzer.static_threshold_analyzer_lib import (
   StaticAnalyzer,
 )
-
-
-def _parse_metric_specs(
-  metric_specs_json: str,
-) -> List[metric_pb2.MetricSpec]:
-  """Parses the JSON metric specifications list into a list of MetricSpec protos."""
-  try:
-    metric_specs_list = json.loads(metric_specs_json)
-  except json.JSONDecodeError as e:
-    print(f"Error: Failed to parse --metric_specs_json: {e}", file=sys.stderr)
-    sys.exit(1)
-
-  # Convert list of dicts to a list of MetricSpec protos
-  metric_specs = []
-  for metric_dict in metric_specs_list:
-    metric_spec = metric_pb2.MetricSpec()
-    json_format.ParseDict(metric_dict, metric_spec)
-    metric_specs.append(metric_spec)
-
-  return metric_specs
 
 
 def _load_benchmark_result(
@@ -76,7 +55,7 @@ def main():
   parser.add_argument("--benchmark_result_file", required=True)
   args = parser.parse_args()
 
-  metric_specs = _parse_metric_specs(args.metric_specs_json)
+  metric_specs = metric_parser.parse_metric_specs_from_json(args.metric_specs_json)
   benchmark_result = _load_benchmark_result(args.benchmark_result_file)
   analyzer = StaticAnalyzer(metric_specs)
   analyzer.run_analysis(benchmark_result)

--- a/benchmarking/tb_parser/BUILD.bazel
+++ b/benchmarking/tb_parser/BUILD.bazel
@@ -34,6 +34,7 @@ py_binary(
     srcs = ["tb_parser.py"],
     deps = [
         ":tb_parser_lib",
+        "//benchmarking/utils:metric_parser",
         "@pypi//protovalidate",
     ],
 )

--- a/benchmarking/tb_parser/tb_parser.py
+++ b/benchmarking/tb_parser/tb_parser.py
@@ -15,39 +15,12 @@
 """Script to extract statistics from TensorFlow event files and produce a BenchmarkResult JSON artifact."""
 
 import argparse
-import json
 import sys
-from typing import List
 from google.protobuf import json_format, timestamp_pb2
+from benchmarking.utils import metric_parser
 from benchmarking.tb_parser import tb_parser_lib
-from benchmarking.proto.common import metric_pb2
 from benchmarking.proto import benchmark_result_pb2
 from protovalidate import validate, ValidationError
-
-
-def _parse_metric_specs(
-  metric_specs_json: str,
-) -> List[metric_pb2.MetricSpec]:
-  """Parses the JSON metric specifications list into a list of MetricSpec protos."""
-
-  try:
-    metric_specs_list = json.loads(metric_specs_json)
-  except json.JSONDecodeError as e:
-    print(f"Error: Failed to parse --metric_specs_json: {e}", file=sys.stderr)
-    sys.exit(1)
-
-  # Convert list of metric spec dicts to a list of MetricSpec protos
-  metric_specs = []
-
-  if not metric_specs_list:
-    return metric_specs
-
-  for metric_dict in metric_specs_list:
-    metric_spec = metric_pb2.MetricSpec()
-    json_format.ParseDict(metric_dict, metric_spec)
-    metric_specs.append(metric_spec)
-
-  return metric_specs
 
 
 def _format_validation_error(violation) -> str:
@@ -80,7 +53,7 @@ def main():
 
   args = parser.parse_args()
 
-  metric_specs = _parse_metric_specs(args.metric_specs_json)
+  metric_specs = metric_parser.parse_metric_specs_from_json(args.metric_specs_json)
   tb_parser = tb_parser_lib.TensorBoardParser(metric_specs)
   computed_stats = tb_parser.parse_and_compute(args.tblog_dir)
 

--- a/benchmarking/utils/BUILD.bazel
+++ b/benchmarking/utils/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "metric_parser",
+    srcs = ["metric_parser.py"],
+    visibility = ["//benchmarking:__subpackages__"],
+    deps = [
+        "//benchmarking/proto/common:metric_py_proto",
+    ],
+)

--- a/benchmarking/utils/metric_parser.py
+++ b/benchmarking/utils/metric_parser.py
@@ -1,0 +1,32 @@
+"""Utility library for parsing metric specifications from JSON."""
+
+import json
+import sys
+from typing import List
+from google.protobuf import json_format
+from benchmarking.proto.common import metric_pb2
+
+
+def parse_metric_specs_from_json(
+  metric_specs_json: str,
+) -> List[metric_pb2.MetricSpec]:
+  """Parses a JSON string into a list of MetricSpec protos.
+
+  Gracefully handles "null" or empty inputs by returning an empty list.
+  """
+  try:
+    metric_specs_list = json.loads(metric_specs_json)
+  except json.JSONDecodeError as e:
+    print(f"Error: Failed to parse metric_specs_json: {e}", file=sys.stderr)
+    sys.exit(1)
+
+  metric_specs = []
+  if not metric_specs_list:
+    return metric_specs
+
+  for metric_dict in metric_specs_list:
+    metric_spec = metric_pb2.MetricSpec()
+    json_format.ParseDict(metric_dict, metric_spec)
+    metric_specs.append(metric_spec)
+
+  return metric_specs

--- a/python_seed_env/src/seed_env/core.py
+++ b/python_seed_env/src/seed_env/core.py
@@ -257,15 +257,11 @@ class EnvironmentSeeder:
         self.requirements_txt = os.path.join(self.output_dir, self.requirements_txt)
 
       if self.requirements_txt == HOST_REQUIREMENTS_FILE:
+        suffix = "".join(map(lambda _: hexdigits[randint(0, 16)], range(5)))
         alts = (
           os.path.join(self.output_dir, "requirements.txt"),
           os.path.join(self.output_dir, "requirements-gen.txt"),
-          os.path.join(
-            self.output_dir,
-            f"requirements-{
-              ''.join(map(lambda _: hexdigits[randint(0, 16)], range(5)))
-            }.txt",
-          ),
+          os.path.join(self.output_dir, f"requirements-{suffix}.txt"),
         )
         raise FileNotFoundError(
           f"Expected unique requirements.txt file found existing {HOST_REQUIREMENTS_FILE}. "


### PR DESCRIPTION
This PR deduplicates the metric parsing logic by extracting it into a shared Bazel library, and applies the recent "artifact-only" null-handling fix to the static threshold analyzer.