### PR TITLE
Add reusable GitHub Action for license header checks

### DIFF
--- a/.github/workflows/test_license_check.yml
+++ b/.github/workflows/test_license_check.yml
@@ -1,0 +1,44 @@
+# A workflow to test check-license composite action
+
+name: Test CI License Check Action
+# Run on pull_request or push
+on:
+  pull_request:
+    paths:
+      - .github/actions/check-license/**
+      - tests/ci_license/**
+      - .github/workflows/test_license_check.yml
+    branches:
+      - main
+  push:
+    paths:
+      - .github/actions/check-license/**
+      - tests/ci_license/**
+      - .github/workflows/test_license_check.yml
+    branches:
+      - main
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  run-license-check:
+    runs-on: "ubuntu-latest"
+    container: "us-central1-docker.pkg.dev/tensorflow-sigs/tensorflow/ml-build:latest" # zizmor: ignore[unpinned-images]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: "Set up Go"
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 'stable'
+      - name: "Run license check successfully"
+        uses: ./ci_check_license
+        with:
+          scan-path: "tests/ci_license/licensed_files"
+          copyright-holder: "Google LLC"
+          license-type: "apache"

--- a/.github/workflows/test_license_check_on_error.yml
+++ b/.github/workflows/test_license_check_on_error.yml
@@ -1,0 +1,55 @@
+# A workflow to test check-license composite action failure conditions
+
+name: Test CI License Check On Error Action
+# Run on pull_request or push
+on:
+  pull_request:
+    paths:
+      - .github/actions/check-license/**
+      - tests/ci_license/**
+      - .github/workflows/test_license_check_on_error.yml
+    branches:
+      - main
+  push:
+    paths:
+      - .github/actions/check-license/**
+      - tests/ci_license/**
+      - .github/workflows/test_license_check_on_error.yml
+    branches:
+      - main
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  run-license-check:
+    runs-on: "ubuntu-latest"
+    container: "us-central1-docker.pkg.dev/tensorflow-sigs/tensorflow/ml-build:latest"  # zizmor: ignore[unpinned-images]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: "Set up Go"
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 'stable'
+      - name: "Run license check on error action"
+        id: check-license
+        uses: ./ci_check_license
+        with:
+          scan-path: "tests/ci_license/unlicensed_files"
+          copyright-holder: "Google LLC"
+          license-type: "apache"
+          exclude-paths: "tests/ci_license/unlicensed_files/excluded_path"
+          exclude-extensions: 'yml'
+          exclude-files: 'tests/ci_license/unlicensed_files/excluded.py'
+        continue-on-error: true
+      - name: "Check license check result failed as expected"
+        if: steps.check-license.outcome == 'failure'
+        run: echo "License check failed as expected."
+      - name: "Check license check result did not fail as expected"
+        if: steps.check-license.outcome != 'failure'
+        run: echo "::error::License check did not fail as expected." && exit 1

--- a/ci_check_license/README.md
+++ b/ci_check_license/README.md
@@ -1,0 +1,66 @@
+# Check License Headers
+
+This composite action helps maintain consistent licensing headers across your codebase by running `addlicense` on source and configuration files. It checks for missing license declarations and causes the workflow to fail if any unlicensed files are found, ensuring strict code compliance.
+
+The action dynamically prunes standard non-source and metadata files (like Lockfiles, JSON configs, Doxygen configurations, and documentation structures) by default, and allows full customization of target paths, exclusions, and copyright signatures.
+
+## Usage
+
+Add this step to your GitHub Actions workflow:
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Run License Header Check
+        uses: ./.github/actions/check-license/
+```
+
+## Inputs
+
+*   **`copyright-holder`**: (Optional) The copyright holder name to check in the header. Defaults to `The TensorFlow Authors`.
+*   **`license-type`**: (Optional) The license type to verify (e.g., `apache`, `mit`, `bsd`). Defaults to `apache`.
+*   **`exclude-paths`**: (Optional) Comma-separated list of folder paths to prune/exclude from the scan. Defaults to `third_party`.
+*   **`exclude-extensions`**: (Optional) Comma-separated list of additional file extensions to exclude (e.g., `tflite, tfrecord, lite`).
+*   **`exclude-files`**: (Optional) Comma-separated list of additional specific filenames or patterns to exclude (e.g., `tensorflow_issue_template.yaml`).
+*   **`scan-path`**: (Optional) The directory path where the scan should begin. Defaults to directory root (`.`).
+
+### Example with custom exclusions and license type
+
+```yaml
+- name: Run License Header Check
+  uses: ./.github/actions/check-license/
+  with:
+    copyright-holder: "Google LLC"
+    license-type: "mit"
+    scan-path: "src"
+    exclude-paths: "src/external, src/generated"
+    exclude-extensions: "json, xml"
+```
+
+## Resolving License Failures
+If a workflow run fails due to missing licenses, you're expected to add headers to the problematic files. Simply run `addlicense` locally on the flagged files:
+`addlicense -c "<copyright_holder>" -l <license_type> <files>`
+and then commit the modified files back to your branch/pull request.
+
+## Default Exclusions
+
+`addlicense` only processes file types it recognises (those with a defined comment style). Binary, image, data, and other unrecognised extensions are silently skipped by the tool itself, so they don't need to appear in the ignore list. The action only explicitly excludes file types that `addlicense` would otherwise process but that don't require license headers:
+
+| Category | Extensions / Files |
+|----------|-------------------|
+| **Build System** | `.bazel`, `.bzl`, `.BUILD` |
+| **Config / Markup** | `.Dockerfile`, `Dockerfile`, `.html`, `.xml`, `.proto` |
+| **Python** | `__init__.py` (typically empty or auto-generated) |
+
+You can add additional exclusions using the `exclude-extensions` and `exclude-files` inputs.
+
+
+## Go Requirement
+This action leverages `go install` to reliably install and run `addlicense` (if it is not already present in your runner environment), ensuring exact tool consistency. If Go is not yet installed in your job runner, you will need to include a step to set it up beforehand, such as using `actions/setup-go`.

--- a/ci_check_license/action.yml
+++ b/ci_check_license/action.yml
@@ -1,0 +1,100 @@
+name: 'Check License Headers'
+description: 'Reusable Action that scans workspace files for Apache or custom license headers, with highly configurable exclusions'
+inputs:
+  copyright-holder:
+    description: 'The copyright holder name to check in the header.'
+    required: true
+  license-type:
+    description: 'The license type to verify (e.g., apache, mit, bsd).'
+    required: true
+  exclude-paths:
+    description: 'Comma-separated list of folder paths to prune/exclude.'
+    required: false
+    default: ''
+  exclude-extensions:
+    description: 'Comma-separated list of additional file extensions to exclude (e.g. tflite, tfrecord).'
+    required: false
+    default: ''
+  exclude-files:
+    description: 'Comma-separated list of additional specific filenames to exclude (e.g. my_custom_template.yaml).'
+    required: false
+    default: ''
+  scan-path:
+    description: 'The directory path where the scan should begin (defaults to repository root).'
+    required: false
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Install addlicense if not present'
+      shell: bash
+      run: |
+        if ! command -v addlicense &> /dev/null; then
+          echo "addlicense CLI not found. Installing github.com/google/addlicense..."
+          go install github.com/google/addlicense@b289835c0741ba2fb92dd5f61af070e79c69a55e # v1.2.0
+        fi
+
+    - name: 'Run license header checks'
+      shell: bash
+      env:
+        INPUT_EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+        INPUT_EXCLUDE_EXTENSIONS: ${{ inputs.exclude-extensions }}
+        INPUT_EXCLUDE_FILES: ${{ inputs.exclude-files }}
+        INPUT_SCAN_PATH: ${{ inputs.scan-path }}
+        INPUT_COPYRIGHT_HOLDER: ${{ inputs.copyright-holder }}
+        INPUT_LICENSE_TYPE: ${{ inputs.license-type }}
+      run: |
+        # Ensure Go bin path is active in current execution env
+        export PATH=$PATH:$(go env GOPATH)/bin
+
+        # Build addlicense arguments
+        ADDLICENSE_ARGS=(
+          -c "$INPUT_COPYRIGHT_HOLDER"
+          -l "$INPUT_LICENSE_TYPE"
+          -check
+        )
+
+        DEFAULT_IGNORE_PATTERNS=(
+          "**/*.Dockerfile" "**/Dockerfile"
+          "**/__init__.py" "_toc.yaml"
+          "**/*.bazel" "**/*.bzl" "**/*.BUILD"
+          "**/*.proto" "**/*.xml" "**/*.html"
+        )
+
+        for pattern in "${DEFAULT_IGNORE_PATTERNS[@]}"; do
+          ADDLICENSE_ARGS+=(-ignore "$pattern")
+        done
+
+        # Add user-supplied path exclusions
+        IFS=', ' read -r -a paths <<< "$INPUT_EXCLUDE_PATHS"
+        for p in "${paths[@]}"; do
+          [[ -n "$p" ]] && ADDLICENSE_ARGS+=(-ignore "${p%/}/**")
+        done
+
+        # Add user-supplied extension exclusions
+        IFS=', ' read -r -a exts <<< "$INPUT_EXCLUDE_EXTENSIONS"
+        for ext in "${exts[@]}"; do
+          [[ -n "$ext" ]] && ADDLICENSE_ARGS+=(-ignore "**/*.${ext#\*.}")
+        done
+
+        # Add user-supplied file exclusions
+        IFS=', ' read -r -a files <<< "$INPUT_EXCLUDE_FILES"
+        for f in "${files[@]}"; do
+          [[ -n "$f" ]] && ADDLICENSE_ARGS+=(-ignore "**/$f")
+        done
+
+        echo "Scanning path: $INPUT_SCAN_PATH"
+        echo "Running addlicense with ${#ADDLICENSE_ARGS[@]} arguments..."
+
+        if ! addlicense "${ADDLICENSE_ARGS[@]}" "$INPUT_SCAN_PATH"; then
+          echo "::error::License header check failed — the files listed above are missing license headers."
+          echo ""
+          echo "To fix, run addlicense on the flagged files:"
+          echo "  addlicense -c \"$INPUT_COPYRIGHT_HOLDER\" -l $INPUT_LICENSE_TYPE <file1> <file2> ..."
+          echo ""
+          echo "Then commit the updated files back to your branch."
+          exit 1
+        fi
+
+        echo "::notice::All files scanned under '$INPUT_SCAN_PATH' contain valid license headers."

--- a/tests/ci_license/licensed_files/valid.py
+++ b/tests/ci_license/licensed_files/valid.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+def hello():
+  print("Hello world")

--- a/tests/ci_license/unlicensed_files/excluded.py
+++ b/tests/ci_license/unlicensed_files/excluded.py
@@ -1,0 +1,3 @@
+# file with no header
+def hello():
+  print("hello world")

--- a/tests/ci_license/unlicensed_files/excluded_extension.yml
+++ b/tests/ci_license/unlicensed_files/excluded_extension.yml
@@ -1,0 +1,1 @@
+name: Excluded Extension

--- a/tests/ci_license/unlicensed_files/excluded_path/invalid.py
+++ b/tests/ci_license/unlicensed_files/excluded_path/invalid.py
@@ -1,0 +1,2 @@
+def hello():
+  print("hello world")

--- a/tests/ci_license/unlicensed_files/invalid.cpp
+++ b/tests/ci_license/unlicensed_files/invalid.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello, World!" << std::endl;
+    return 0;
+}

--- a/tests/ci_license/unlicensed_files/invalid.py
+++ b/tests/ci_license/unlicensed_files/invalid.py
@@ -1,0 +1,3 @@
+# file with no license header
+def hello():
+  print("hello world")


### PR DESCRIPTION
Adds a reusable composite GitHub Action for checking license headers across repository files using `addlicense`, along with CI workflows and fixtures to validate both successful and failing license-check scenarios.

## What changed

- Added a new `ci_check_license` composite action that:
  - Installs `github.com/google/addlicense` if it is not already available.
  - Checks files for required license headers.
  - Supports configurable copyright holder and license type.
  - Supports configurable scan path.
  - Provides default ignore patterns for common generated, metadata, and non-source files.
  - Allows additional exclusions by path, file extension, or filename.
  - Emits GitHub Actions errors/notices for clear CI feedback.

- Added documentation for the new action, including:
  - Usage examples.
  - Available inputs.
  - Custom exclusion examples.
  - Guidance for resolving license check failures.
  - Go setup requirements.

- Added CI workflows to validate the action:
  - A success workflow that checks properly licensed files.
  - A failure-condition workflow that verifies the action fails on unlicensed files while respecting configured exclusions.

- Added test fixtures for:
  - A valid licensed source file.
  - Unlicensed files expected to fail the check.
  - Unlicensed files excluded by path, extension, or filename.

## Testing

The new workflows exercise the license-check action in both expected success and expected failure modes:

- Licensed test files are scanned and should pass.
- Unlicensed test files are scanned and should fail.
- Excluded paths, file extensions, and files are verified to be ignored during failure testing.